### PR TITLE
add timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The `opts` argument may either be a string URI of the proxy server to use, or an
   * `port` - Number - Proxy port to connect to. Required.
   * `secureProxy` - Boolean - If `true`, then use TLS to connect to the proxy. Defaults to `false`.
   * `secureEndpoint` - Boolean - If `true` then a TLS connection to the endpoint will be established on top of the proxy socket. Defaults to `true`.
+  * `timeout` - Number - Proxy response timeout in milliseconds.
   * Any other options given are passed to the `net.connect()`/`tls.connect()` functions.
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -190,6 +190,26 @@ describe('HttpsProxyAgent', function () {
         done();
       });
     });
+    it('should emit an "error" event on the `http.ClientRequest` if the proxy times out', function(done) {
+      // ensure we timeout after the "error" event had a chance to trigger
+      this.timeout(1000);
+
+      var agent = new HttpsProxyAgent({
+        host: '255.0.0.1', // unsassigned address, should timeout
+        port: 8080,
+        timeout: 500
+      });
+
+      var opts = url.parse('http://nodejs.org');
+      opts.agent = agent;
+
+      var req = http.get(opts);
+      req.once('error', function(err) {
+        assert.equal('ETIMEOUT', err.code);
+        req.abort();
+        done();
+      });
+    });
   });
 
   describe('"https" module', function () {


### PR DESCRIPTION
I finally did it ! This is extensively tested and shouldn't break.

I still have a bug when setting also a _request_ timeout with core http client: sometimes error events are emitted (like ECONNRESET) after the request's `timeout` event, but I don't think it's related to https-proxy-agent at all since it happens after the proxy connection has been successfuly established. I will investigate it further and submit a pull if necessary.
