### PR TITLE
:arrow_up: update minimum version of debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "agent-base": "2",
-    "debug": "2",
+    "debug": "^2.4.1",
     "extend": "3"
   },
   "devDependencies": {


### PR DESCRIPTION
To avoid running into [this bug](visionmedia/debug#356) in the `debug` package.

It would be great to make a new patch release after this has been merge so that downstream packages can depend on at least that version.