### PR TITLE
Dont offer "ALPN: h2" to https-proxy

### DIFF
--- a/https-proxy-agent.js
+++ b/https-proxy-agent.js
@@ -65,7 +65,7 @@ function connect (req, opts, fn) {
   // create a socket connection to the proxy server
   var socket;
   if (this.secureProxy) {
-    socket = tls.connect(proxy);
+    socket = tls.connect(proxy, {ALPNProtocols: ['http 1.1']});
   } else {
     socket = net.connect(proxy);
   }


### PR DESCRIPTION
Currently, there're some https/http2 both mode proxies(i.e. goproxy-vps, nghttpx)
Offer "ALPN: h2" during connect then send plain http/1.1 request will confuse the https-proxy servers.

This issue is similar with https://github.com/curl/curl/issues/1254

Fix it by `tls.connect(proxy, {ALPNProtocols: ['http 1.1']})`

Signed-off-by: Phus Lu <phuslu@hotmail.com>