### PR TITLE
Set ALPN to http1.1 by default when using tlsproxy

### DIFF
--- a/https-proxy-agent.js
+++ b/https-proxy-agent.js
@@ -40,6 +40,10 @@ function HttpsProxyAgent (opts) {
   proxy.host = proxy.hostname || proxy.host;
   proxy.port = +proxy.port || (this.secureProxy ? 443 : 80);
 
+  if (this.secureProxy) {
+    proxy.ALPNProtocols = proxy.ALPNProtocols || ['http 1.1']
+  }
+
   if (proxy.host && proxy.path) {
     // if both a `host` and `path` are specified then it's most likely the
     // result of a `url.parse()` call... we need to remove the `path` portion so


### PR DESCRIPTION
Currently, there're some https/http2 both mode proxies(i.e. goproxy-vps, nghttpx)
Offer "ALPN: h2" during connect then send plain http/1.1 request will confuse the https-proxy servers.

This issue is similar with https://github.com/curl/curl/issues/1254

Fix it by set `proxy.ALPNProtocols` to `['http 1.1']` by default.

Signed-off-by: Phus Lu <phuslu@hotmail.com>