### PR TITLE
Send other SSL options into tls.connect()

### DIFF
--- a/https-proxy-agent.js
+++ b/https-proxy-agent.js
@@ -136,11 +136,13 @@ function connect (req, opts, fn) {
         // since the proxy is connecting to an SSL server, we have
         // to upgrade this socket connection to an SSL connection
         debug('upgrading proxy-connected socket to TLS connection: %o', opts.host);
+        opts.ca = proxy.ca;
         opts.socket = socket;
         opts.servername = opts.host;
         opts.host = null;
         opts.hostname = null;
         opts.port = null;
+        opts.rejectUnauthorized = proxy.rejectUnauthorized;
         sock = tls.connect(opts);
       }
 


### PR DESCRIPTION
Custom certificate config (e.g. via `npm config set cafile`) isn't making their way into `tls.connect()`, this appears to be an `npm@5` regression.

This pull ensures the option is passed from `npm` -> `pacote` -> `make-fetch-happen` then right into `https-proxy-agent`'s `tls.connect()` call.

See the discussion here: https://github.com/npm/npm/issues/16868