### PR TITLE
Add defaultPort field to the HttpsProxyAgent

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ function HttpsProxyAgent(opts) {
   }
 
   this.proxy = proxy;
+  this.defaultPort = 443;
 }
 inherits(HttpsProxyAgent, Agent);
 


### PR DESCRIPTION
This adds a `defaultPort` field to every instance of the `HttpsProxyAgent` so that Node's internal `https.request` does not add the `:443` port to the `Host` header [here](https://github.com/nodejs/node/blob/master/lib/_http_client.js#L157-L159).

**Note**: This is different from d7a4c70, which only controls the client's request to the Proxy but not the proxied request to the actual server.

**Details:** Node's `ClientRequest` checks the `defaultPort` option and the agent's `defaultPort` and only adds the port to the `Host` header of the actual request if it differs from the `port` option. `agent-base` ensures that this port is always `443` (see [here](https://github.com/TooTallNate/node-agent-base/blob/master/patch-core.js#L20)). Certain applications, such as the AWS/S3 client, even expect this port number to be absent when signing the HTTP request. Therefore, the port must not be added unless it differs from the default.