### PR TITLE
TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+declare module 'https-proxy-agent' {
+    import * as https from 'https'
+
+    namespace HttpsProxyAgent {
+        interface HttpsProxyAgentOptions {
+            host: string
+            port: number
+            secureProxy?: boolean
+            headers?: {
+                [key: string]: string
+            }
+            [key: string]: any
+        }
+    }
+    
+    // HttpsProxyAgent doesnt *actually* extend https.Agent, but for my purposes I want it to pretend that it does
+    class HttpsProxyAgent extends https.Agent {
+        constructor(opts: HttpsProxyAgent.HttpsProxyAgentOptions)
+    }
+
+    export = HttpsProxyAgent
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.1",
   "description": "An HTTP(s) proxy `http.Agent` implementation for HTTPS",
   "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "mocha --reporter spec"
   },


### PR DESCRIPTION
This PR is just to bring attention to the missing type definitions. Not everyone uses TypeScript, but for those who do, having this file in this repo would be incredibly helpful.

`index.d.ts` is based on: https://github.com/TooTallNate/node-https-proxy-agent/issues/27#issuecomment-389298156 (thank you @yonilerner)

Please let us know if this is ok! Any form of feedback is appreciated.