### PR TITLE
feat(typescript): Allow input to be options or string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare module 'https-proxy-agent' {
     
     // HttpsProxyAgent doesnt *actually* extend https.Agent, but for my purposes I want it to pretend that it does
     class HttpsProxyAgent extends https.Agent {
-        constructor(opts: HttpsProxyAgent.HttpsProxyAgentOptions)
+        constructor(opts: HttpsProxyAgent.HttpsProxyAgentOptions | string)
     }
 
     export = HttpsProxyAgent


### PR DESCRIPTION
Following up from #66, the constructor can be either the options object or a string (see https://github.com/TooTallNate/node-https-proxy-agent/blob/master/index.js#L27)
