### PR TITLE
fix(typings): allow port to be a string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module 'https-proxy-agent' {
     namespace HttpsProxyAgent {
         interface HttpsProxyAgentOptions {
             host: string
-            port: number
+            port: number | string
             secureProxy?: boolean
             headers?: {
                 [key: string]: string


### PR DESCRIPTION
Fixing a regression spotted in pnpm: https://github.com/pnpm/pnpm/pull/1905

The port in the Node.js URL object is a string, so it is more convenient to use string for the port.
https://nodejs.org/api/url.html#url_url_port