### PR TITLE
Use a `net.Socket` instead of a plain `EventEmitter` for replaying proxy errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/test/test.js
+++ b/test/test.js
@@ -234,6 +234,24 @@ describe('HttpsProxyAgent', function() {
 				done();
 			});
 		});
+    it('should not error if the request is aborted and a fake socket is assigned to it', function(done) {
+      proxy.authenticate = function(req, fn) {
+        fn(null, false);
+      };
+
+      const proxyUri =
+        process.env.HTTP_PROXY ||
+        process.env.http_proxy ||
+        'http://127.0.0.1:' + proxyPort;
+
+      const req = http.get({ agent: new HttpsProxyAgent(proxyUri) });
+
+      req.on('socket', function() {
+        req.abort();
+      })
+
+      req.on('abort', done);
+    });
 		it('should emit an "error" event on the `http.ClientRequest` if the proxy does not exist', function(done) {
 			// port 4 is a reserved, but "unassigned" port
 			var proxyUri = 'http://127.0.0.1:4';

--- a/test/test.js
+++ b/test/test.js
@@ -234,24 +234,25 @@ describe('HttpsProxyAgent', function() {
 				done();
 			});
 		});
-    it('should not error if the request is aborted and a fake socket is assigned to it', function(done) {
-      proxy.authenticate = function(req, fn) {
-        fn(null, false);
-      };
+		it('should not error if the proxy responds with 407 and the request is aborted', function(done) {
+			proxy.authenticate = function(req, fn) {
+				fn(null, false);
+			};
 
-      const proxyUri =
-        process.env.HTTP_PROXY ||
-        process.env.http_proxy ||
-        'http://127.0.0.1:' + proxyPort;
+			const proxyUri =
+				process.env.HTTP_PROXY ||
+				process.env.http_proxy ||
+				'http://127.0.0.1:' + proxyPort;
 
-      const req = http.get({ agent: new HttpsProxyAgent(proxyUri) });
+			const req = http.get({
+				agent: new HttpsProxyAgent(proxyUri)
+			}, function(res) {
+				assert.equal(407, res.statusCode);
+				req.abort();
+			});
 
-      req.on('socket', function() {
-        req.abort();
-      })
-
-      req.on('abort', done);
-    });
+			req.on('abort', done);
+		});
 		it('should emit an "error" event on the `http.ClientRequest` if the proxy does not exist', function(done) {
 			// port 4 is a reserved, but "unassigned" port
 			var proxyUri = 'http://127.0.0.1:4';


### PR DESCRIPTION
Fixes: https://github.com/TooTallNate/node-https-proxy-agent/issues/81