### PR TITLE
Push the EOF signaling `null` chunk after replaying proxy errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,6 +187,7 @@ HttpsProxyAgent.prototype.callback = function connect(req, opts, fn) {
 		// replay the "buffers" Buffer onto the `socket`, since at this point
 		// the HTTP module machinery has been hooked up for the user
 		socket.push(buffers);
+		socket.push(null);
 
 		// nullify the cached Buffer instance
 		buffers = null;

--- a/test/test.js
+++ b/test/test.js
@@ -251,6 +251,28 @@ describe('HttpsProxyAgent', function() {
 
 			req.on('abort', done);
 		});
+		it('should emit an "end" event on the `http.IncomingMessage` if the proxy responds with non-200 status code', function(done) {
+			proxy.authenticate = function(req, fn) {
+				fn(null, false);
+			};
+
+			const proxyUri =
+				process.env.HTTP_PROXY ||
+				process.env.http_proxy ||
+				'http://localhost:' + proxyPort;
+
+			const req = http.get(
+				{
+					agent: new HttpsProxyAgent(proxyUri)
+				},
+				function(res) {
+					assert.equal(407, res.statusCode);
+
+					res.resume();
+					res.on('end', done);
+				}
+			);
+		});
 		it('should emit an "error" event on the `http.ClientRequest` if the proxy does not exist', function(done) {
 			// port 4 is a reserved, but "unassigned" port
 			var proxyUri = 'http://localhost:4';


### PR DESCRIPTION
Allow the `'end'` event to be emitted on the `http.IncomingMessage`
instance.

Fixes: https://github.com/TooTallNate/node-https-proxy-agent/issues/87