### PR TITLE
Fix compatibility with Node.js 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [6.x, 8.x, 10.x, 12.x]
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x]
 
     runs-on: ${{ matrix.os }}
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -162,7 +162,7 @@ export default class HttpsProxyAgent extends Agent {
 		// See: https://hackerone.com/reports/541502
 		socket.destroy();
 
-		const fakeSocket = new net.Socket();
+		const fakeSocket = new net.Socket({ writable: false });
 		fakeSocket.readable = true;
 
 		// Need to wait for the "socket" event to re-play the "data" events.


### PR DESCRIPTION
If the socket is writable, a write is attempted and an
`ERR_SOCKET_CLOSED` error is emitted because the socket was never
connected.