### PR TITLE
Add TLS version config

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -139,10 +139,12 @@ export default class HttpsProxyAgent extends Agent {
 				// this socket connection to a TLS connection.
 				debug('Upgrading socket connection to TLS');
 				const servername = opts.servername || opts.host;
+				const minVersion =  proxy.minVersion || 'TLSv1';
 				return tls.connect({
 					...omit(opts, 'host', 'hostname', 'path', 'port'),
 					socket,
-					servername
+					servername,
+					minVersion,
 				});
 			}
 
@@ -210,3 +212,4 @@ function omit<T extends object, K extends [...(keyof T)[]]>(
 	}
 	return ret;
 }
+


### PR DESCRIPTION
This PR will allow passing a minimal TLS version to the proxy request configuration.
The default version is "TLSv1" which is the lowest, it might be better to use a newer version but I didn't want to break anything.