### PR TITLE
update agent-base package to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/TooTallNate/node-https-proxy-agent/issues"
   },
   "dependencies": {
-    "agent-base": "6",
+    "agent-base": "6.0.2",
     "debug": "4"
   },
   "devDependencies": {


### PR DESCRIPTION
resolves `Protocol "https:" not supported. Expected "http:"` error in Node.js v16
Fixes #126